### PR TITLE
age: Embed testdata

### DIFF
--- a/age/age.go
+++ b/age/age.go
@@ -1,0 +1,22 @@
+// Package agetest embeds the age test vectors for use by Go programs.
+package agetest
+
+import (
+	"embed"
+	"io/fs"
+)
+
+// Vectors contains all the generated test vectors, one per file,
+// in the root of the filesystem.
+var Vectors fs.FS
+
+//go:embed testdata
+var testdata embed.FS
+
+func init() {
+	var err error
+	Vectors, err = fs.Sub(testdata, "testdata")
+	if err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
Age can now declare a dependency on c2sp.org/CCTV/age and feed test vectors testkit without needing to run `go mod download` from `TestVectors`.